### PR TITLE
获取设备信息方法完善mac的判断

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -339,7 +339,7 @@ Lay.fn.device = function(key){
       } else if(/linux/.test(agent)){
         return 'linux';
       } else if(/mac/.test(agent)){
-        return ‘mac’;
+        return 'mac';
       } else if(/iphone|ipod|ipad|ios/.test(agent)){
         return 'ios';
       }

--- a/src/layui.js
+++ b/src/layui.js
@@ -338,6 +338,8 @@ Lay.fn.device = function(key){
         return 'windows';
       } else if(/linux/.test(agent)){
         return 'linux';
+      } else if(/mac/.test(agent)){
+        return ‘mac’;
       } else if(/iphone|ipod|ipad|ios/.test(agent)){
         return 'ios';
       }


### PR DESCRIPTION
获取设备信息的功能，在mac下 获取到的 device.os 未定义，增加了mac的判断。

（第一次发pull request，改动很小，建议加上windows的版本判断）