### PR TITLE
增加是mac os 的判断条件

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -334,6 +334,8 @@ Lay.fn.device = function(key){
         return 'linux';
       } else if(/iphone|ipod|ipad|ios/.test(agent)){
         return 'ios';
+      } else if(/mac os/.test(agent)){
+        return 'mac os';
       }
     }()
     ,ie: function(){ //ie版本


### PR DESCRIPTION
layui.device().os
增加是mac os 的判断条件