### PR TITLE
修复 当select标签没有option元素时，使用 Form.render() 渲染会出错的问题

### DIFF
--- a/src/lay/modules/form.js
+++ b/src/lay/modules/form.js
@@ -235,7 +235,7 @@ layui.define('layer', function(exports){
 
           //替代元素
           var reElem = $(['<div class="layui-unselect '+ CLASS + (disabled ? ' layui-select-disabled' : '') +'">'
-            ,'<div class="'+ TITLE +'"><input type="text" placeholder="'+ (select.options[0].innerHTML ? select.options[0].innerHTML : TIPS) +'" value="'+ (value ? selected.html() : '') +'" '+ (isSearch ? '' : 'readonly') +' class="layui-input layui-unselect'+ (disabled ? (' '+DISABLED) : '') +'">'
+            ,'<div class="'+ TITLE +'"><input type="text" placeholder="'+ (select.options.length && select.options[0].innerHTML ? select.options[0].innerHTML : TIPS) +'" value="'+ (value ? selected.html() : '') +'" '+ (isSearch ? '' : 'readonly') +' class="layui-input layui-unselect'+ (disabled ? (' '+DISABLED) : '') +'">'
             ,'<i class="layui-edge"></i></div>'
             ,'<dl class="layui-anim layui-anim-upbit'+ (othis.find('optgroup')[0] ? ' layui-select-group' : '') +'">'+ function(options){
               var arr = [];


### PR DESCRIPTION
在渲染时，判断只判断了 `options[0].innerHTML` ，而没有判断 `options.length` ，这就导致渲染会失败