### PR TITLE
修复 prompt 设置值包含特殊字符时，显示会出错的问题

### DIFF
--- a/src/lay/modules/layer.js
+++ b/src/lay/modules/layer.js
@@ -964,7 +964,11 @@ layer.prompt = function(options, yes){
     delete options.area;
   }
   var prompt, content = options.formType == 2 ? '<textarea class="layui-layer-input"' + style +'>' + (options.value||'') +'</textarea>' : function(){
-    return '<input type="'+ (options.formType == 1 ? 'password' : 'text') +'" class="layui-layer-input" value="'+ (options.value||'') +'">';
+    var input = document.createElement('input');
+    input.type = 1 == options.formType ? "password" : "text";
+    input.classList.add("layui-layer-input");
+    input.setAttribute('value', (options.value || ""));
+    return input.outerHTML;
   }();
   
   var success = options.success;


### PR DESCRIPTION
修复 在打开prompt时，如果设置的value包含 `<`或 `"` 等字符时，值不能正确显示的输入框内的问题