### PR TITLE
当服务端返回的数据不符合laytable约定格式时,可通过传入的resultConverter函数进行转换

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -242,6 +242,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         }, options.where)
         ,dataType: 'json'
         ,success: function(res){
+          if(options.resultConverter != undefined){
+              options.resultConverter(res);
+          }
           if(res.code != 0){
             return layer.msg(res.msg);
           }


### PR DESCRIPTION
通常服务端返回的数据不一定符合laytable约定格式, 因此需要支持自定义转换函数，对数据进行转换。如：
var resultConverter = function(res){
                res.code = 0;
                res.count = res.total;
                delete res.total;
                res.data = res.data;
                res.msg = res.message;
                delete res.message;
            };
var ins1 = table.render({
                elem: '#myTable'
                ,url: '/query/data.json'
                ,where: {}
                ,resultConverter: resultConverter
                ,cols: [[
                    //...                 
                ]]
                ,page: true
                ,height: 350
            });
