### PR TITLE
添加浏览器端测试

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - node
+dist: trusty
 addons:
   sauce_connect: true
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: node_js
-dist: trusty
-addons:
-  chrome: stable
 node_js:
   - node
-#addons:
-#  sauce_connect: true
+addons:
+  sauce_connect: true
 sudo: false
 cache:
   directories:
     - node_modules
 script:
   - npm run test:cov
-  #- npm run test:sauce
+  - npm run test:sauce
 after_script: 
   - npm install coveralls && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,9 @@ cache:
 script:
   - npm run test:cov
   - npm run test:sauce
-after_script: 
+after_script:
   - npm install coveralls && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+env:
+  global:
+    - SAUCE_USERNAME=layui
+    - secure: PHeqcsxnHrNJJDw+gnSnh2HgSEcz83BlhPa/C+rTxP2+DGNX7/WFcoQidM9X3Zoi2NQ5kZ9d9sZsxyK1OSI2YIWeUn9F5KOe1AkdQnQzR4N/0in8CJFnEe14BFujlVghyU2afKWNwoml22VdrboQvZpVsp6zDtGBnslAWxUIAEc3V+HWlBVJdVzOg/Hm09RowbLo+WXk1Z8kU95nf2+5p2UFwkeeMh9JqSYkyNAKR2Jlbk+u7Qx2DbTWik7t3+7FYe432PKm4SImbWLClMOqYtTl3zdT5SKw6oupat2hWMaeBo7mDSTiFNemNkuYgoxAdBYegxjUVyDmyB+EkKn6bHD4pfjaiCWV6CL5JBjkgxruuucKG8q1+z7K7peMc4RF91+AAsdmouzM+J/r80b3ZEDQVh8Mze48tgMJArncb1isptEDm7orqVFchHyzn+95fa1Q4i7aJ7upimq7Y65DbCU762UT21BtQVoa4syWnNmRAxa20YIVxWWkYfga2tJr8xlQ3Rt3xVIRG35FgEt4Ytk1JsaZpLo6Nj3O5LP+oqJ6SEPXwNS8genvYdcwoRzpfxLfXebTXGkWaNfHlpc7JjTG8koJ1b2tk/4VJ6/x1bi5Bx0fwAaF3UoENdt9OpJnND/mYpQACVMj05zO+pZN501CztbNNzp/xPypyn7Nxmg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,3 @@ script:
   - npm run test:sauce
 after_script:
   - npm install coveralls && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
-env:
-  global:
-    - SAUCE_USERNAME=layui
-    - secure: PHeqcsxnHrNJJDw+gnSnh2HgSEcz83BlhPa/C+rTxP2+DGNX7/WFcoQidM9X3Zoi2NQ5kZ9d9sZsxyK1OSI2YIWeUn9F5KOe1AkdQnQzR4N/0in8CJFnEe14BFujlVghyU2afKWNwoml22VdrboQvZpVsp6zDtGBnslAWxUIAEc3V+HWlBVJdVzOg/Hm09RowbLo+WXk1Z8kU95nf2+5p2UFwkeeMh9JqSYkyNAKR2Jlbk+u7Qx2DbTWik7t3+7FYe432PKm4SImbWLClMOqYtTl3zdT5SKw6oupat2hWMaeBo7mDSTiFNemNkuYgoxAdBYegxjUVyDmyB+EkKn6bHD4pfjaiCWV6CL5JBjkgxruuucKG8q1+z7K7peMc4RF91+AAsdmouzM+J/r80b3ZEDQVh8Mze48tgMJArncb1isptEDm7orqVFchHyzn+95fa1Q4i7aJ7upimq7Y65DbCU762UT21BtQVoa4syWnNmRAxa20YIVxWWkYfga2tJr8xlQ3Rt3xVIRG35FgEt4Ytk1JsaZpLo6Nj3O5LP+oqJ6SEPXwNS8genvYdcwoRzpfxLfXebTXGkWaNfHlpc7JjTG8koJ1b2tk/4VJ6/x1bi5Bx0fwAaF3UoENdt9OpJnND/mYpQACVMj05zO+pZN501CztbNNzp/xPypyn7Nxmg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ node_js:
   - node
 dist: trusty
 addons:
-  sauce_connect: true
+  sauce_connect:
+    username: "layui"
+    access_key: "8d5b59cf-94c0-44fa-8432-726f6502ca5c"
 sudo: false
 cache:
   directories:

--- a/karma.conf.base.js
+++ b/karma.conf.base.js
@@ -57,7 +57,16 @@ module.exports = function (config) {
 
 
         // list of files / patterns to load in the browser
-        files: sourceFileMap.concat('test/**/*.js'),
+        files: sourceFileMap.concat('test/**/*.js').concat({
+            pattern: 'src/css/**/*',
+            included: false
+        }, {
+            pattern: 'src/font/**/*',
+            included: false
+        }, {
+            pattern: 'src/images/**/*',
+            included: false
+        }),
 
 
         // list of files to exclude

--- a/karma.conf.sauce.js
+++ b/karma.conf.sauce.js
@@ -84,7 +84,7 @@ module.exports = function (config) {
     var options = Object.assign(base(config), {
         reporters: ['mocha', 'saucelabs'],
         sauceLabs: {
-            'testName': 'layui test case',
+            'testName': 'layui',
             'recordVideo': false,
             'recordScreenshots': false,
             'startConnect': false,
@@ -92,7 +92,7 @@ module.exports = function (config) {
                 'no-ssl-bump-domains': 'all'
             },
             'public': 'public',
-            'build': process.env.CIRCLE_BUILD_NUM || process.env.SAUCE_BUILD_ID || 'build-' + Date.now(),
+            'build': 'layui-build-' + process.env.TRAVIS_BUILD_NUMBER,
             'tunnelIdentifier': process.env.TRAVIS_JOB_NUMBER
         },
         customLaunchers: customLaunchers,

--- a/karma.conf.sauce.js
+++ b/karma.conf.sauce.js
@@ -35,11 +35,11 @@ var customLaunchers = {
         browserName: 'chrome'
     },
 
-    sl_ie_8: {
-        base: 'SauceLabs',
-        browserName: 'internet explorer',
-        version: '8'
-    },
+    // sl_ie_8: {
+    //     base: 'SauceLabs',
+    //     browserName: 'internet explorer',
+    //     version: '8'
+    // },
     sl_ie_9: {
         base: 'SauceLabs',
         browserName: 'internet explorer',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "layui",
-  "version": "2.1.0",
-  "layimV": "3.7.0",
+  "version": "2.0.1",
   "description": "经典模块化前端框架",
   "main": "layui.js",
   "license": "MIT",
@@ -18,28 +17,28 @@
   "author": "贤心",
   "homepage": "http://www.layui.com",
   "devDependencies": {
+    "chai": "^4.1.1",
+    "del": "^2.2.2",
     "gulp": "^3.9.1",
-    "gulp-uglify": "^1.5.4",
     "gulp-concat": "^2.6.0 ",
     "gulp-header": "^1.8.8",
     "gulp-if": "^2.0.1",
     "gulp-minify-css": "^1.2.4",
     "gulp-rename": "^1.2.2",
-    "del": "^2.2.2",
+    "gulp-uglify": "^1.5.4",
     "gulp-zip": "^4.0.0",
-    "minimist": "^1.2.0",
-    "chai": "^3.5.0",
     "karma": "^1.5.0",
     "karma-chai": "^0.1.0",
     "karma-chai-sinon": "^0.1.5",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",
-    "karma-sauce-launcher": "^1.1.0",
     "karma-mocha-reporter": "^2.2.3",
     "karma-phantomjs-launcher": "^1.0.4",
+    "karma-sauce-launcher": "^1.1.0",
+    "minimist": "^1.2.0",
     "mocha": "^3.2.0",
-    "sinon": "^2.0.0",
-    "sinon-chai": "^2.8.0"
+    "sinon": "^3.2.1",
+    "sinon-chai": "^2.13.0"
   },
   "bugs": {
     "url": "https://github.com/sentsin/layui/issues"
@@ -48,8 +47,7 @@
     "doc": "doc",
     "test": "test"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "keywords": [
     "layui",
     "ui"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "layui",
-  "version": "2.0.1",
+  "version": "2.1.0",
+  "layimV": "3.7.0",
   "description": "经典模块化前端框架",
   "main": "layui.js",
   "license": "MIT",

--- a/test/laytpl.js
+++ b/test/laytpl.js
@@ -213,7 +213,8 @@ describe('laytpl', function () {
     it('error var', function () {
       var result = laytpl('{{ data.xxoo }}').render({});
 
-      expect(result).to.have.string('Can\'t find variable: data');
+      expect(result).to.have.string('data');
+      expect(result).to.have.string('ReferenceError');
       expect(result).to.have.string('Laytpl Error');
     });
 
@@ -221,7 +222,7 @@ describe('laytpl', function () {
       var result = laytpl('{{# var xxoo = ; }}').render({});
 
       expect(result).to.have.string('Laytpl Error');
-      expect(result).to.have.string('Unexpected token \';\'');
+      expect(result).to.have.string('SyntaxError');
     });
   });
 });


### PR DESCRIPTION
1. 添加了chrome, firefox, ie9+测试, 目前`karma`基础测试对ie8支持有问题, 已经有人提PR了: <https://github.com/karma-runner/karma/pull/2821>
1. 测试持续集成流程