### PR TITLE
lay-ignore属性不处理而不是展示出来

### DIFF
--- a/src/lay/modules/form.js
+++ b/src/lay/modules/form.js
@@ -251,7 +251,7 @@ layui.define('layer', function(exports){
           ,selected = $(select.options[select.selectedIndex]) //获取当前选中项
           ,optionsFirst = select.options[0];
           
-          if(typeof othis.attr('lay-ignore') === 'string') return othis.show();
+          if(typeof othis.attr('lay-ignore') === 'string') return true;
           
           var isSearch = typeof othis.attr('lay-search') === 'string'
           ,placeholder = optionsFirst ? (


### PR DESCRIPTION
我有一个select，这个时候逻辑需要把他隐藏。
此时重新渲染页面，因为配置了lay-ignore属性，又会把它展示出来。
因此，处理的方式应该是保持原样式而不是直接展示出来。