### PR TITLE
优化 doc 文件夹内 md 格式

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # 注意事项：
-* 页面的HTML代码必须是 <!DOCTYPE html> 开头
-* 除ie6、7外，所有浏览器均支持
+* 页面的HTML代码必须是 `<!DOCTYPE html>` 开头
+* 除IE6、7外，所有浏览器均支持
 
 # 在线文档
 [http://www.layui.com/doc/](http://www.layui.com/doc/)


### PR DESCRIPTION
`<!DOCTYPE html>` 在 GitHub 在线浏览时显示不出来，加上了行内代码。