### PR TITLE
加入HTML得accpet支持

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -88,7 +88,7 @@ layui.define('layer' , function(exports){
     var that = this
     ,options = that.config
     ,elemFile = that.elemFile = $([
-      '<input class="'+ ELEM_FILE +'" type="file" name="'+ options.field +'"'
+      '<input class="'+ ELEM_FILE +'" type="file" accept="'+ options.domAccept +'" name="'+ options.field +'"'
       ,(options.multiple ? ' multiple' : '') 
       ,'>'
     ].join(''))


### PR DESCRIPTION
用于点击上传按钮后  打开系统文件框时， 默认的文件筛选
例：
上传图片： accpet="image/*"