### PR TITLE
修复自适应时溢出的选项卡最后一个tab选中时关闭不会切换到其他tab

### DIFF
--- a/src/lay/modules/element.js
+++ b/src/lay/modules/element.js
@@ -122,7 +122,7 @@ layui.define('jquery', function(exports){
       ,filter = parents.attr('lay-filter');
       
       if(li.hasClass(THIS)){
-        if(li.next()[0]){
+        if(li.next('li')[0]){
           call.tabClick.call(li.next()[0], null, index + 1);
         } else if(li.prev()[0]){
           call.tabClick.call(li.prev()[0], null, index - 1);


### PR DESCRIPTION
bug复现操作步骤：
1. 新建一个带删除的选项卡，宽度设置200px；
2. 设置10个tab使选项卡溢出（自动隐藏）；
3. 下拉显示所有选项卡，选中最后一个tab；
4. 删除最后一个tab，不会切换到其他tab，bug复现。

已经修复
