### PR TITLE
layedit build 第一个参数支持html对象

### DIFF
--- a/src/lay/modules/layedit.js
+++ b/src/lay/modules/layedit.js
@@ -54,7 +54,7 @@ layui.define(['layer', 'form'], function(exports){
     
     var that = this
     ,config = that.config
-    ,ELEM = 'layui-layedit', textArea = $('#'+id)
+    ,ELEM = 'layui-layedit', textArea = $(typeof(id)=='string'?'#'+id:id)
     ,name =  'LAY_layedit_'+ (++that.index)
     ,haveBuild = textArea.next('.'+ELEM)
     


### PR DESCRIPTION
更新layedit的build方法，使其第一个参数支持传入原生html textarea对象。
layui已经非常好用了，但是每个页面底部的layui.use 以及其内部逻辑仍然让开发着觉得麻烦和厌倦，本人在快速开发中尝试将layui的use以及其逻辑尽量自动化。在自动化过程中，发现这里有必要做一下支持。
```
<textarea class="layedit"></textarea>
...
<textarea class="layedit"></textarea>
<script>
layui.use(['jquery','layedit'],function(){
    var $ = layui.$,layedit=layui.layedit;
    $('.layedit').each(function(i,o){
        $(o).hide();
        layedit.build(o,{});
    });
});
</script>
```