### PR TITLE
修复 carousel 模块 timer 泄露的 bug

### DIFF
--- a/src/lay/modules/carousel.js
+++ b/src/lay/modules/carousel.js
@@ -164,6 +164,7 @@ layui.define('jquery', function(exports){
     
     if(!options.autoplay) return;
     
+    clearInterval(that.timer);
     that.timer = setInterval(function(){
       that.slide();
     }, options.interval);


### PR DESCRIPTION
设想自动播放（options.autoplay === true）时以下事件依次发生：

mouseenter            -- 原 timer 被清除
ajax 触发了 reload()  -- 设置新的timer
mouseleave            --  reload() 设置的timer被直接覆盖，导致无法停止动画播放