### PR TITLE
动态删除form表单项提交数据问题

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -1262,11 +1262,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
   
   //表格重载
   thisTable.config = {};
-  table.reload = function(id, options){
+  table.reload = function(id, options, ez){
     var config = thisTable.config[id];
     options = options || {};
     if(!config) return hint.error('The ID option was not found in the table instance');
     if(options.data && options.data.constructor === Array) delete config.data;
+    if(ez) config.where = options.where;
     return table.render($.extend(true, {}, config, options));
   };
  


### PR DESCRIPTION
在表单中使用 name="filed[]" 表单项时，动态增加大于2个表单项后提交，然后在删除其中一项表单项在提交后，会发现删除的表单项在提交至后端中并没有被删除，产生这个问题的原因是由于extend的特性所产生的，所以我在解决这个问题的时候在reload中增加了一个参数来判断是否用新数据替代旧数据，同样的问题在开源中国社区中也有人遇到，他解决的方式是写了一个复杂的过滤逻辑感觉很不nice