### PR TITLE
修复laydate.js模块checkDate方法里的initDate对时分秒校验的bug

### DIFF
--- a/src/lay/modules/laydate.js
+++ b/src/lay/modules/laydate.js
@@ -878,15 +878,15 @@
           if(thisv < 1) thisv = 1, error = true;
           dateTime.date = thisv;
         } else if(/HH|H/.test(item)){ //时
-          if(thisv < 1) thisv = 0, error = true;
+          if(thisv < 0) thisv = 0, error = true;
           dateTime.hours = thisv;
           options.range && (that[startEnd[index]].hours = thisv);
         } else if(/mm|m/.test(item)){ //分
-          if(thisv < 1) thisv = 0, error = true;
+          if(thisv < 0) thisv = 0, error = true;
           dateTime.minutes = thisv;
           options.range && (that[startEnd[index]].minutes = thisv);
         } else if(/ss|s/.test(item)){ //秒
-          if(thisv < 1) thisv = 0, error = true;
+          if(thisv < 0) thisv = 0, error = true;
           dateTime.seconds = thisv;
           options.range && (that[startEnd[index]].seconds = thisv);
         }


### PR DESCRIPTION
该bug导致在校验包含时/分/秒的时间格式时,会被判定为error=true,具体示例如下:
**操作**: 点击 清空
**现象**: date1可正常清空,  而date2会被设为初始值



           laydate.render({
                elem: '#date1'
                ,type: 'date'
                ,value: "2018-01-01"
            });

            laydate.render({
                elem: '#date2'
                ,type: 'datetime'
                ,value: "2018-01-01 00:00:00"
            });

