### PR TITLE
form.js模块select下拉项第一节点不为option时,替换DOM结构错误的问题

### DIFF
--- a/src/lay/modules/form.js
+++ b/src/lay/modules/form.js
@@ -417,7 +417,8 @@ layui.define('layer', function(exports){
             ,function(options){
               var arr = [];
               layui.each(options, function(index, item){
-                if(index === 0 && !item.value){
+                //修复当第一项就是optgroup时,被替换为<dd><option></option></dd>的结构错误的问题,应该替换为<dt></dt>
+                if(index === 0 && !item.value && item.nodeName.toLowerCase === 'option'){
                   arr.push('<dd lay-value="" class="layui-select-tips">'+ (item.innerHTML || TIPS) +'</dd>');
                 } else if(item.tagName.toLowerCase() === 'optgroup'){
                   arr.push('<dt>'+ item.label +'</dt>'); 


### PR DESCRIPTION
当第一项就是optgroup时,被替换为<dd><option></option></dd>的结构错误的问题, 正确的应该替换为<dt></dt>
对比以下两个替换后的DOM结构可知问题.
    <select name="test1" class="layui-select">
        <option value="">请选择</option>
        <optgroup label="group1">
            <option value="1">option1</option>
        </optgroup>
    </select>

    <select name="test2" class="layui-select">
        <optgroup label="group1">
            <option value="1">option1</option>
        </optgroup>
    </select>