### PR TITLE
在使用 table 时，遇到请求参数对象的一个数组属性在修改后，实际发出的请求数组属性却未改变

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -644,7 +644,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     delete that.haveInit;
     
     if(options.data && options.data.constructor === Array) delete that.config.data;
-    that.config = $.extend(true, {}, that.config, options);
+    that.config = $.extend({}, that.config, options);
     
     that.render();
   };


### PR DESCRIPTION
在使用 table 时，遇到请求参数对象的一个数组属性在修改后，实际发出的请求数组属性却未改变，经研究，导致该问题的结果如下：

```js
            var object1 = { arr: ["123", "456"] };
            var object2 = { arr: [] };
            var deepMerge = $.extend(true, {}, object1, object2);
            console.log("deepMerge", deepMerge);        // 输出：deepMerge {arr: ["123", "456"]}
```

修改为：
```js
            var shallowMerge = $.extend({}, object1, object2);
            console.log("shallowMerge", shallowMerge);  // 输出：shallowMerge {arr: []}
```
，则正常