### PR TITLE
Change table's height to its parent container's height

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -283,7 +283,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     //高度铺满：full-差距值
     if(options.height && /^full-\d+$/.test(options.height)){
       that.fullHeightGap = options.height.split('-')[1];
-      options.height = _WIN.height() - that.fullHeightGap;
+      options.height = options.elem.parent().height() - that.fullHeightGap;
     }
     
     //初始化一些参数
@@ -1157,7 +1157,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     ,height = options.height, bodyHeight;
 
     if(that.fullHeightGap){
-      height = _WIN.height() - that.fullHeightGap;
+      height = that.elem.parent().height() - that.fullHeightGap;
       if(height < 135) height = 135;
       that.elem.css('height', height);
     }


### PR DESCRIPTION
Current option height attribute `full-xxx` use window to calculate table container's height. In most case, we place the table in a `div` tag, and the table adapting to the div container, or its parent container(maybe `body`). I think it's better to use this way to calculate table container's height.