### PR TITLE
fix bug of element.js, function tabClick

### DIFF
--- a/src/lay/modules/element.js
+++ b/src/lay/modules/element.js
@@ -99,7 +99,7 @@ layui.define('jquery', function(exports){
     tabClick: function(e, index, liElem, options){
       options = options || {};
       var othis = liElem || $(this)
-      ,index = index || othis.parent().children('li').index(othis)
+      ,index = index === 0 ? index : index || othis.parent().children('li').index(othis)
       ,parents = options.headerElem ? othis.parent() : othis.parents('.layui-tab').eq(0)
       ,item = options.bodyElem ? $(options.bodyElem) : parents.children('.layui-tab-content').children('.layui-tab-item')
       ,elemA = othis.find('a')


### PR DESCRIPTION
我发现使用element.tab方法自定义title和content的时候，点第一个选项卡传入tabClick的index会是0，并且如果title不是ul>li，这时候第一个选项卡的index会被计算为-1，加一个全等判断index为0的情况
I found that when using the element.tab method to customize the title and content, click the first tab, index of the tabClick passed in will be 0, and if the title is not "ul>li", the index of the first tab will be calculated as -1, add one Sequential judgment when the index is 0