### PR TITLE
修复某些情况下 获取layui所在目录 不正确的bug

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -27,11 +27,17 @@
     var jsPath = doc.currentScript ? doc.currentScript.src : function(){
       var js = doc.scripts
       ,last = js.length - 1
-      ,src;
-      for(var i = last; i > 0; i--){
-        if(js[i].readyState === 'interactive'){
-          src = js[i].src;
-          break;
+      ,src
+      ,layuiJs = Array.from(js).find(x => x.src.toLowerCase().indexOf("/layui.js") != -1);
+      if(!layuiJs){
+        src = layuiJs.src;
+      }
+      else{
+        for(var i = last; i > 0; i--){
+          if(js[i].readyState === 'interactive'){
+            src = js[i].src;
+            break;
+          }
         }
       }
       return src || js[last].src;


### PR DESCRIPTION
修复某些情况下 获取layui所在目录 不正确的bug。
优先获取 layui.js 文件的 url，避免获取到其他 js文件的url导致识别到的layui目录不正确而无法加载layui模块的问题。