### PR TITLE
update upload.js

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -518,7 +518,12 @@ layui.define('layer' , function(exports){
     
     //手动触发上传
     options.bindAction.off('upload.action').on('upload.action', function(){
-      that.upload();
+      /*修复上传按钮失效等bug-start---by:zYunQiShi(信奉着春风细雨)-2019/11/29*/
+      var copyE=that;
+      copyE.chooseFiles=copyE.files;//获取符合条件的files
+      copyE.upload()  
+      // that.upload();
+      /*修复上传按钮失效等bug-end---by:zYunQiShi(信奉着春风细雨)-2019/11/29*/
     });
     
     //防止事件重复绑定


### PR DESCRIPTION
修复upload.js的bug-：
1.选择添加了几个文件之后，再点击选择，这是候不添加新的文件，上传功能失效 ’。
同时修复了以下潜在bug:
点击【选择文件】按钮正常选择第一个文件，再点击【选择文件】按钮-》弹出文件选择框，选择不符合自定义条件的文件（比如文件size限制在2m却选择了大于2m的文件,文件格式…），就会做出相应的警告提醒（比如‘文件不能超过2.00MB’），之后才点击【上传文件】按钮，则又会弹出上一次的警告且上传文件按钮失效。