### PR TITLE
修复 input name 属性缺失会导致 field 缺失，无法正常上传文件

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -109,7 +109,7 @@ layui.define('layer' , function(exports){
     
     that.isFile() ? (
       that.elemFile = options.elem
-      ,options.field = options.elem[0].name
+      ,options.field = options.elem[0].name ? options.elem[0].name : options.field
     ) : options.elem.after(elemFile);
     
     //初始化ie8/9的Form域


### PR DESCRIPTION
情况如下： 在options中配置了 field
`uploadListIns = upload.render({
                    elem: '#getPic-before',
                    url: sheReport.data.url.uploadFile,
                    accept: 'file',
                    multiple: true,
                    field: 'files', 
                    auto: false,
                    bindAction: '#submitBtn',`

`<input type="file" id="getPic-before" class="getPic" multiple />`
选择文件容器未配置 name 属性，最终会导致 options 中的 field 未 ""