### PR TITLE
根据exts的值规定打开文件选择框时，筛选出的文件类型,可自定义类型

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -91,8 +91,9 @@ layui.define('layer' , function(exports){
   Class.prototype.file = function(){
     var that = this
     ,options = that.config
+    ,extAccept = options.exts.split('|').map(e => {return '.' + e}).join(',')
     ,elemFile = that.elemFile = $([
-      '<input class="'+ ELEM_FILE +'" type="file" accept="'+ options.acceptMime +'" name="'+ options.field +'"'
+      '<input class="'+ ELEM_FILE +'" type="file" accept="'+ (options.acceptMime ? options.acceptMime + ',' + extAccept : extAccept) +'" name="'+ options.field +'"'
       ,(options.multiple ? ' multiple' : '') 
       ,'>'
     ].join(''))


### PR DESCRIPTION
使用upload上传文件的时候，有些特殊文件没有MIME扩展名，没有办法自动筛选掉，而文件域支持通过后缀指定类型。通过简单的exts修改即可支持自定义后缀文件
[https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/Input/file#attr-accept](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/Input/file#attr-accept)